### PR TITLE
Don't return early when a file is downloaded

### DIFF
--- a/chatmail2mastodon/util.py
+++ b/chatmail2mastodon/util.py
@@ -76,7 +76,7 @@ def toots2replies(bot: Bot, toots: Iterable) -> Generator:
                 with download_file(reply.file) as path:
                     reply.file = path
                     yield reply
-                return
+                    continue
             except Exception as ex:
                 bot.logger.exception(ex)
                 text = reply.text or ""


### PR DESCRIPTION
I don't know if it's a bug, but I couldn't send a bunch of messages when one had an attachment since it was returning early