### PR TITLE
Follow hashtags

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ If someone sends you a direct message in a private 1:1 conversation, it will be 
 
 and the chat with "friend@example.com" will pop up.
 
+You can follow hashtags and group of hashtags. To do that:
+
+1. Create a group with the bot
+2. Set the name of the group with the hashtags you want to follow separated by a space, for example "#deltachat #chatmail"
+3. Send a message to send the group creation to the bot.
+
+The bot will set the group avatar to the same as the "Home" and "Notifications" avatar. Every message that matches any of the hashtags will be sent in the group. To follow other hashtags you can modify the name or create other groups. To stop any following in a chat, just leave the chat.
+
 To logout from your account:
 
 ```

--- a/chatmail2mastodon/hooks.py
+++ b/chatmail2mastodon/hooks.py
@@ -102,6 +102,10 @@ def on_added(bot: Bot, accid: int, event: CoreEvent) -> None:
         if len(contact_ids) != 1:
             return
 
+        info = bot.rpc.get_basic_chat_info(accid, chatid)
+        tags = re.split(r'[ ,]+', info.name)
+        if False in [tag.startswith('#') for tag in tags]:
+            return
         hashtags = session.query(Hashtags).filter_by(chat_id=chatid).first()
         if not hashtags:
 

--- a/chatmail2mastodon/hooks.py
+++ b/chatmail2mastodon/hooks.py
@@ -22,7 +22,7 @@ from rich.logging import RichHandler
 
 from .cli import cli
 from .migrations import run_migrations
-from .orm import Account, DmChat, OAuth, initdb, session_scope
+from .orm import Account, DmChat, OAuth, Hashtags, initdb, session_scope
 from .util import (
     TOOT_SEP,
     Visibility,
@@ -82,9 +82,40 @@ def log_event(bot: Bot, accid: int, event: CoreEvent) -> None:
                 chatid = bot.rpc.create_chat_by_contact_id(accid, event.contact_id)
                 send_help(bot, accid, chatid)
 
+@cli.on(events.RawEvent(types=EventType.CHAT_MODIFIED))
+def on_added(bot: Bot, accid: int, event: CoreEvent) -> None:
+    """Process member-added messages"""
+    chatid = event.chat_id
+
+    with session_scope() as session:
+        dmchat = session.query(DmChat).filter_by(chat_id=chatid).first()
+        if dmchat:
+            return
+        home = session.query(Account).filter_by(home=chatid).first()
+        if home:
+            return
+        notif = session.query(Account).filter_by(notifications=chatid).first()
+        if notif:
+            return
+
+        contact_ids = [c for c in bot.rpc.get_chat_contacts(accid, chatid) if c != SpecialContactId.SELF]
+        if len(contact_ids) != 1:
+            return
+
+        hashtags = session.query(Hashtags).filter_by(chat_id=chatid).first()
+        if not hashtags:
+
+            contact_id = contact_ids[0]
+            session.add(Hashtags(chat_id=chatid, contactid=contact_id))
+
+            try:
+                bot.rpc.set_chat_profile_image(accid, chatid, MASTODON_LOGO)
+            except Exception as err:
+                bot.logger.exception(err)
+
 
 @cli.on(events.NewMessage(is_info=True))
-def on_info_msg(bot: Bot, accid: int, event: NewMsgEvent) -> None:
+def on_removed(bot: Bot, accid: int, event: NewMsgEvent) -> None:
     """Process member-removed messages"""
     msg = event.msg
     chatid = msg.chat_id
@@ -120,6 +151,11 @@ def on_info_msg(bot: Bot, accid: int, event: NewMsgEvent) -> None:
             if dmchat:
                 chats.append(chatid)
                 session.delete(dmchat)
+            else:
+                hashtags = session.query(Hashtags).filter_by(chat_id=chatid).first()
+                if hashtags:
+                    chats.append(chatid)
+                    session.delete(hashtags)
 
     for chatid in chats:
         try:
@@ -745,6 +781,8 @@ Use /login to log in, once you log in with your Mastodon credentials, two chats 
     • The Notifications chat is where you will receive your Mastodon notifications.
 
     When a Mastodon user writes a private/direct message to you, a chat will be created for your private conversation with that user.
+
+    To follow hashtags, create a group with you and the bot, set the name to the hashtags you want to follow separated by a space (for example "#deltachat #chatmail", you can change anytime). You can create as many groups as you want.
 
 **Available commands**
 

--- a/chatmail2mastodon/hooks.py
+++ b/chatmail2mastodon/hooks.py
@@ -4,6 +4,7 @@ import os
 from argparse import Namespace
 from pathlib import Path
 from threading import Thread
+import re
 
 import mastodon
 from deltachat2 import (
@@ -104,11 +105,11 @@ def on_added(bot: Bot, accid: int, event: CoreEvent) -> None:
 
         info = bot.rpc.get_basic_chat_info(accid, chatid)
         tags = re.split(r'[ ,]+', info.name)
-        if False in [tag.startswith('#') for tag in tags]:
+        if len(info.name.strip()) == 0 or False in [tag.startswith('#') for tag in tags]:
             return
+
         hashtags = session.query(Hashtags).filter_by(chat_id=chatid).first()
         if not hashtags:
-
             contact_id = contact_ids[0]
             session.add(Hashtags(chat_id=chatid, contactid=contact_id))
 

--- a/chatmail2mastodon/migrations.py
+++ b/chatmail2mastodon/migrations.py
@@ -149,3 +149,16 @@ def migrate3(bot: Bot, database: sqlite3.Connection) -> None:
                 (conid, row["url"], row["user"], row["client_id"], row["client_secret"]),
             )
         database.execute("DROP TABLE old_oauth")
+
+
+def migrate4(bot: Bot, database: sqlite3.Connection) -> None:
+    database.execute(
+        """"
+        CREATE TABLE hashtags (
+                    chat_id INTEGER PRIMARY KEY,
+                    contactid INTEGER NOT NULL,
+                    last VARCHAR(1000),
+                    Foreign KEY(contactid) REFERENCES account (id)
+            )
+        """
+    )

--- a/chatmail2mastodon/orm.py
+++ b/chatmail2mastodon/orm.py
@@ -24,7 +24,7 @@ class Account(Base):
     muted_notif = Column(Boolean)
 
     dm_chats = relationship("DmChat", backref="account", cascade="all, delete, delete-orphan")
-
+    hashtags = relationship("Hashtags", backref="account", cascade="all, delete, delete-orphan")
 
 class DmChat(Base):
     __tablename__ = "dmchat"
@@ -32,6 +32,11 @@ class DmChat(Base):
     contactid = Column(Integer, ForeignKey("account.id"), nullable=False)
     contact = Column(String(1000), nullable=False)
 
+class Hashtags(Base):
+    __tablename__ = "hashtags"
+    chat_id = Column(Integer, primary_key=True)
+    contactid = Column(Integer, ForeignKey("account.id"), nullable=False)
+    last = Column(String(1000))
 
 class OAuth(Base):
     __tablename__ = "oauth"

--- a/chatmail2mastodon/util.py
+++ b/chatmail2mastodon/util.py
@@ -103,8 +103,8 @@ def toot2reply(toot: AttribAccessDict) -> MsgData:
     if toot.media_attachments:
         first = toot.media_attachments.pop(0)
         reply.file = first.url
-        text += f"[{first.description}]\n\n"
-        text += "\n\n".join(f"{media.url}\n[{media.description}]" for media in toot.media_attachments) + "\n\n"
+        text += f"[{first.description or 'no alt'}]\n\n"
+        text += "\n\n".join(f"{media.url}\n[{media.description or 'no alt'}]" for media in toot.media_attachments) + "\n\n"
 
     soup = BeautifulSoup(toot.content, "html.parser")
     if toot.mentions:

--- a/chatmail2mastodon/util.py
+++ b/chatmail2mastodon/util.py
@@ -101,8 +101,10 @@ def toot2reply(toot: AttribAccessDict) -> MsgData:
         reply.override_sender_name = _get_name(toot.account)
 
     if toot.media_attachments:
-        reply.file = toot.media_attachments.pop(0).url
-        text += "\n".join(media.url for media in toot.media_attachments) + "\n\n"
+        first = toot.media_attachments.pop(0)
+        reply.file = first.url
+        text += f"[{first.description}]\n\n"
+        text += "\n\n".join(f"{media.url}\n[{media.description}]" for media in toot.media_attachments) + "\n\n"
 
     soup = BeautifulSoup(toot.content, "html.parser")
     if toot.mentions:

--- a/chatmail2mastodon/util.py
+++ b/chatmail2mastodon/util.py
@@ -102,7 +102,9 @@ def toot2reply(toot: AttribAccessDict) -> MsgData:
 
     if toot.media_attachments:
         first = toot.media_attachments.pop(0)
-        reply.file = first.url
+        reply.file = first.preview_url or first.preview_remote_url or first.url
+        if reply.file != first.url:
+            text += first.url + "\n"
         text += f"[{first.description or 'no alt'}]\n\n"
         text += "\n\n".join(f"{media.url}\n[{media.description or 'no alt'}]" for media in toot.media_attachments) + "\n\n"
 

--- a/chatmail2mastodon/util.py
+++ b/chatmail2mastodon/util.py
@@ -21,6 +21,7 @@ from mastodon import (
     MastodonNetworkError,
     MastodonServerError,
     MastodonUnauthorizedError,
+    MastodonRatelimitError
 )
 from pydub import AudioSegment
 
@@ -333,7 +334,7 @@ def _check_mastodon(bot: Bot, args: Namespace) -> None:
                     chatid = bot.rpc.create_chat_by_contact_id(accid, conid)
                     text = f"❌ ERROR Your account was logged out: {ex}"
                     bot.rpc.send_msg(accid, chatid, MsgData(text=text))
-                except (MastodonNetworkError, MastodonServerError) as ex:
+                except (MastodonNetworkError, MastodonServerError, MastodonRatelimitError) as ex:
                     bot.logger.exception(ex)
                 except Exception as ex:  # noqa
                     bot.logger.exception(ex)
@@ -396,7 +397,7 @@ def get_mastodon(api_url: str, token: Optional[str] = None, **kwargs) -> Mastodo
     return Mastodon(
         access_token=token,
         api_base_url=api_url,
-        ratelimit_method="wait",
+        ratelimit_method="throw",
         session=web,
         **kwargs,
     )

--- a/chatmail2mastodon/util.py
+++ b/chatmail2mastodon/util.py
@@ -611,8 +611,11 @@ def _check_hashtags(
 
         for tag in tags:
             t = masto.timeline_hashtag(tag, min_id=lasts.get(tag), limit=100)
-            toots.extend(t)
+            toots.extend([tt for tt in t if tt.id not in [to.id for to in toots]]) # Remove duplicates
             newlasts[tag] = t[0].id if t else lasts.get(tag)
+
+        # re-sort
+        toots.sort(key=lambda s: s.edited_at if s.edited_at else s.created_at)
 
         bot.logger.debug(f"{len(toots)} toots matching {info.name}")
         for reply in toots2replies(bot, reversed(toots)):

--- a/chatmail2mastodon/util.py
+++ b/chatmail2mastodon/util.py
@@ -10,6 +10,7 @@ from enum import Enum
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Generator, Iterable, List, Optional
 import json
+import random
 
 import requests
 from bs4 import BeautifulSoup
@@ -600,7 +601,8 @@ def _check_hashtags(
         for chat in hashtags_chats:
             chats.append((chat.last, chat.chat_id))
 
-    for (last, chat_id) in chats:
+    # Randomize chats to have a chance to check them all in case of throttling
+    for (last, chat_id) in random.sample(chats, k=len(chats)):
         toots = []
         info = bot.rpc.get_basic_chat_info(accid, chat_id)
         tags = [tag for tag in re.split(r'\W+', info.name) if tag != '']


### PR DESCRIPTION
Thanks again for the bot it has reduced so much my amount of scrolling !

One thing I really missed is the possibility to follow hashtags. Thanks to that these content I know I want are sent directly, I can read them in the background when I want.

The way I did it is that the user creates a group with them and the bot, named "#deltachat #chatmail" for example, the bot checks the timeline of each and sends toots one by one. They're timelines so there is management of "last" as usual.

The real issue I can see is that it's a lot of calls per user, so the bot gets throttled more.